### PR TITLE
Better multi-screen support

### DIFF
--- a/ShiftIt/WindowSizer.m
+++ b/ShiftIt/WindowSizer.m
@@ -285,7 +285,7 @@ SINGLETON_BOILERPLATE(WindowSizer, sharedWindowSize);
 		[(id)val release];
 
 		
-		if (frame.size.width >= width) {
+		if (frame.size.width > width) {
 			FMTDevLog(@"adjusting size to %dx%d", width/2, height/2);
 			errorCode = AXUISetWindowSize(window, width/2, height/2);
 		}


### PR DESCRIPTION
Resize fails when windows size is larger than the screen size, with no error messages. (window dragged from larger screen)
Is this an OSX bug? I fixed it by resizing the window twice.
