### PR TITLE
Use NSTableView for changing hotkeys in Preferences

### DIFF
--- a/ShiftIt/PreferencesWindow.xib
+++ b/ShiftIt/PreferencesWindow.xib
@@ -7,22 +7,12 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
             <connections>
+                <outlet property="hotkeyColumn" destination="xUe-4S-V3z" id="3cm-hX-8Vr"/>
+                <outlet property="hotkeyColumn_" destination="xUe-4S-V3z" id="Tz3-bY-dRV"/>
+                <outlet property="hotkeyLabelColumn" destination="jfi-Ey-cpD" id="kJv-3i-9vm"/>
+                <outlet property="hotkeyLabelColumn_" destination="jfi-Ey-cpD" id="fx8-DW-vDG"/>
+                <outlet property="hotkeysView_" destination="A5L-ln-QBX" id="HnE-Ja-tSt"/>
                 <outlet property="showMenuIcon" destination="257" id="zQM-A2-jhe"/>
-                <outlet property="srBL_" destination="873" id="917"/>
-                <outlet property="srBR_" destination="874" id="918"/>
-                <outlet property="srBottom_" destination="870" id="903"/>
-                <outlet property="srCenter_" destination="875" id="948"/>
-                <outlet property="srFullScreen_" destination="876" id="949"/>
-                <outlet property="srIncrease_" destination="877" id="920"/>
-                <outlet property="srLeft_" destination="867" id="900"/>
-                <outlet property="srMaximize_" destination="945" id="951"/>
-                <outlet property="srNextScreen_" destination="1819" id="1826"/>
-                <outlet property="srReduce_" destination="878" id="922"/>
-                <outlet property="srRight_" destination="868" id="901"/>
-                <outlet property="srTL_" destination="871" id="923"/>
-                <outlet property="srTR_" destination="872" id="924"/>
-                <outlet property="srTop_" destination="869" id="902"/>
-                <outlet property="srZoom_" destination="941" id="950"/>
                 <outlet property="tabView_" destination="3" id="588"/>
                 <outlet property="versionLabel_" destination="584" id="589"/>
                 <outlet property="window" destination="1" id="242"/>
@@ -167,114 +157,6 @@
                                     <rect key="frame" x="32" y="7" width="299" height="460"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" tag="100" id="517">
-                                            <rect key="frame" x="55" y="423" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Left" id="518">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="519">
-                                            <rect key="frame" x="56" y="399" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Right" id="520">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="521">
-                                            <rect key="frame" x="56" y="375" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Top" id="524">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="522">
-                                            <rect key="frame" x="56" y="351" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bottom" id="523">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="538">
-                                            <rect key="frame" x="55" y="321" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Top Left" id="545">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="539">
-                                            <rect key="frame" x="55" y="297" width="66" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Top Right" id="544">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="540">
-                                            <rect key="frame" x="43" y="273" width="78" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bottom Left" id="543">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="541">
-                                            <rect key="frame" x="34" y="249" width="87" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bottom Right" id="542">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="554">
-                                            <rect key="frame" x="74" y="217" width="46" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Center" id="561">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="555">
-                                            <rect key="frame" x="0.0" y="143" width="120" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Toggle Full Screen" id="560">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="619">
-                                            <rect key="frame" x="28" y="110" width="92" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Increase" id="622">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="620">
-                                            <rect key="frame" x="35" y="86" width="86" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Reduce" id="621">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <button verticalHuggingPriority="750" id="606">
                                             <rect key="frame" x="58" y="9" width="169" height="32"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
@@ -286,138 +168,104 @@
                                                 <action selector="revertDefaults:" target="-2" id="610"/>
                                             </connections>
                                         </button>
-                                        <customView id="867" userLabel="sr_left" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="421" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="904"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="868" userLabel="sr_right" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="396" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="905"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="869" userLabel="sr_top" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="371" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="906"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="870" userLabel="sr_bottom" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="346" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="907"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="871" userLabel="sr_tl" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="318" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="909"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="872" userLabel="sr_tr" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="294" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="910"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="873" userLabel="sr_bl" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="270" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="911"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="874" userLabel="sr_br" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="246" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="912"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="875" userLabel="sr_center" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="214" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="913"/>
-                                            </connections>
-                                        </customView>
-                                        <textField verticalHuggingPriority="750" id="940">
-                                            <rect key="frame" x="29" y="192" width="91" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Toggle Zoom" id="942">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <customView id="941" userLabel="sr_zoom" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="189" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="943"/>
-                                            </connections>
-                                        </customView>
-                                        <textField verticalHuggingPriority="750" id="944">
-                                            <rect key="frame" x="54" y="167" width="65" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Maximize" id="946">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <customView id="945" userLabel="sr_maximize" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="164" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="947"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="876" userLabel="sr_fullScreen" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="140" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="914"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="877" userLabel="sr_increment" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="107" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="915"/>
-                                            </connections>
-                                        </customView>
-                                        <customView id="878" userLabel="sr_decrement" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="83" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="916"/>
-                                            </connections>
-                                        </customView>
-                                        <textField verticalHuggingPriority="750" id="1817">
-                                            <rect key="frame" x="27" y="56" width="92" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Next screen" id="1822">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <customView id="1819" userLabel="sr_nextscreen" customClass="SRRecorderControl">
-                                            <rect key="frame" x="126" y="53" width="160" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <connections>
-                                                <outlet property="delegate" destination="-2" id="1825"/>
-                                            </connections>
-                                        </customView>
+                                        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" id="rX3-at-XFq">
+                                            <rect key="frame" x="3" y="44" width="283" height="399"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="e1O-dF-gHv">
+                                                <rect key="frame" x="0.0" y="0.0" width="283" height="399"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="A5L-ln-QBX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="283" height="399"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <size key="intercellSpacing" width="6" height="2"/>
+                                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                        <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                        <tableColumns>
+                                                            <tableColumn identifier="" width="116" minWidth="40" maxWidth="1000" id="jfi-Ey-cpD">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="jiH-Xs-9qQ">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <prototypeCellViews>
+                                                                    <tableCellView id="I37-Zc-K0g">
+                                                                        <rect key="frame" x="3" y="1" width="116" height="17"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <subviews>
+                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="D78-ZL-Dg3">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="116" height="17"/>
+                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="3ss-15-jqT">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                        </subviews>
+                                                                        <connections>
+                                                                            <outlet property="textField" destination="D78-ZL-Dg3" id="jXq-QN-J71"/>
+                                                                        </connections>
+                                                                    </tableCellView>
+                                                                </prototypeCellViews>
+                                                            </tableColumn>
+                                                            <tableColumn identifier="" width="155" minWidth="40" maxWidth="1000" id="xUe-4S-V3z">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="NP6-3N-EpU">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <prototypeCellViews>
+                                                                    <tableCellView id="9aO-96-dIo">
+                                                                        <rect key="frame" x="125" y="1" width="155" height="17"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <subviews>
+                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="H8B-ri-Egp">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="155" height="17"/>
+                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="9br-JZ-gxa">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                        </subviews>
+                                                                        <connections>
+                                                                            <outlet property="textField" destination="H8B-ri-Egp" id="kwC-2Z-uFg"/>
+                                                                        </connections>
+                                                                    </tableCellView>
+                                                                </prototypeCellViews>
+                                                            </tableColumn>
+                                                        </tableColumns>
+                                                        <connections>
+                                                            <outlet property="dataSource" destination="-2" id="NmQ-uB-FDH"/>
+                                                            <outlet property="delegate" destination="-2" id="yVA-OY-Z5c"/>
+                                                        </connections>
+                                                    </tableView>
+                                                </subviews>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </clipView>
+                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="vZZ-WW-uY4">
+                                                <rect key="frame" x="1" y="118" width="238" height="16"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="JYN-KP-vAH">
+                                                <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                        </scrollView>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/ShiftIt/PreferencesWindowController.h
+++ b/ShiftIt/PreferencesWindowController.h
@@ -23,7 +23,6 @@
 
 @interface PreferencesWindowController : NSWindowController {
  @private
-    NSDictionary *hotKeyControls_;
 	NSString *selectedTabIdentifier_;
     NSString *debugLoggingFile_;
 	
@@ -32,21 +31,9 @@
 
     IBOutlet NSButtonCell *showMenuIcon;
 
-    IBOutlet SRRecorderControl *srLeft_;
-    IBOutlet SRRecorderControl *srRight_;
-    IBOutlet SRRecorderControl *srTop_;
-    IBOutlet SRRecorderControl *srBottom_;    
-    IBOutlet SRRecorderControl *srTL_;
-    IBOutlet SRRecorderControl *srTR_;
-    IBOutlet SRRecorderControl *srBR_;
-    IBOutlet SRRecorderControl *srBL_;
-    IBOutlet SRRecorderControl *srCenter_;
-    IBOutlet SRRecorderControl *srZoom_;
-    IBOutlet SRRecorderControl *srMaximize_;
-    IBOutlet SRRecorderControl *srFullScreen_;
-    IBOutlet SRRecorderControl *srIncrease_;
-    IBOutlet SRRecorderControl *srReduce_;    
-    IBOutlet SRRecorderControl *srNextScreen_;    
+    IBOutlet NSTableView *hotkeysView_;
+    IBOutlet NSTableColumn *hotkeyLabelColumn_;
+    IBOutlet NSTableColumn *hotkeyColumn_;
 }
 
 @property BOOL shouldStartAtLogin;

--- a/ShiftIt/PreferencesWindowController.m
+++ b/ShiftIt/PreferencesWindowController.m
@@ -55,12 +55,6 @@ NSString *const kHotKeysTabViewItemIdentifier = @"hotKeys";
     return self;
 }
 
-- (void)dealloc {
-    [hotKeyControls_ release];
-
-    [super dealloc];
-}
-
 - (BOOL)acceptsFirstResponder {
     return YES;
 }
@@ -77,42 +71,6 @@ NSString *const kHotKeysTabViewItemIdentifier = @"hotKeys";
 
     // no debug logging by default
     [self setDebugLoggingFile:@""];
-
-    // This is just temporary here - till new version
-    NSArray *controls = [NSArray arrayWithObjects:srLeft_,
-                                                  srBottom_,
-                                                  srTop_,
-                                                  srRight_,
-                                                  srTL_,
-                                                  srTR_,
-                                                  srBR_,
-                                                  srBL_,
-                                                  srCenter_,
-                                                  srZoom_,
-                                                  srMaximize_,
-                                                  srFullScreen_,
-                                                  srIncrease_,
-                                                  srReduce_,
-                                                  srNextScreen_,
-                                                  nil];
-    NSArray *keys = [NSArray arrayWithObjects:@"left",
-                                              @"bottom",
-                                              @"top",
-                                              @"right",
-                                              @"tl",
-                                              @"tr",
-                                              @"br",
-                                              @"bl",
-                                              @"center",
-                                              @"zoom",
-                                              @"maximize",
-                                              @"fullScreen",
-                                              @"increase",
-                                              @"reduce",
-                                              @"nextscreen",
-                                              nil];
-
-    hotKeyControls_ = [[NSDictionary dictionaryWithObjects:controls forKeys:keys] retain];
 
     [self updateRecorderCombos];
 }
@@ -225,8 +183,74 @@ NSString *const kHotKeysTabViewItemIdentifier = @"hotKeys";
 
 #pragma mark Shortcut Recorder methods
 
+static NSString *hotkeyIdentifiers[] = {
+    @"left",
+    @"right",
+    @"top",
+    @"bottom",
+    NULL,
+    @"tl",
+    @"tr",
+    @"bl",
+    @"br",
+    NULL,
+    @"center",
+    @"zoom",
+    @"maximize",
+    @"fullScreen",
+    NULL,
+    @"increase",
+    @"reduce",
+    NULL,
+    @"nextscreen",
+};
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+    return sizeof(hotkeyIdentifiers) / sizeof(hotkeyIdentifiers[0]);
+}
+
+- (BOOL)tableView:(NSTableView *)aTableView shouldSelectRow:(NSInteger)rowIndex {
+    return NO;
+}
+
+- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row {
+    FMTAssert(row >= 0 && row < sizeof(hotkeyIdentifiers) / sizeof(hotkeyIdentifiers[0]), @"Row out of range");
+    NSString* identifier = hotkeyIdentifiers[row];
+    if (identifier == NULL)
+        return 1;
+    return 23;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView
+   viewForTableColumn:(NSTableColumn *)tableColumn
+                  row:(NSInteger)row {
+    FMTAssert(row >= 0 && row < sizeof(hotkeyIdentifiers) / sizeof(hotkeyIdentifiers[0]), @"Row out of range");
+    NSString* identifier = hotkeyIdentifiers[row];
+    if (identifier == NULL)
+        return NULL;
+    ShiftItAction *action = [allShiftActions objectForKey:identifier];
+    if (tableColumn == hotkeyLabelColumn_) {
+        NSTextField* text = [[NSTextField alloc] initWithFrame:tableView.frame];
+        text.alignment = NSRightTextAlignment;
+        text.drawsBackground = NO;
+        text.stringValue = action.label;
+        [text setBordered:NO];
+        [text setEditable:NO];
+        return text;
+    }
+    if (tableColumn == hotkeyColumn_) {
+        SRRecorderControl* recorder = [[SRRecorderControl alloc] initWithFrame:tableView.frame];
+        recorder.delegate = self;
+        recorder.identifier = identifier;
+        [self updateRecorderCombo:recorder forIdentifier:identifier];
+        return recorder;
+    }
+    FMTFail(@"Unknown tableView or tableColumn");
+    return NULL;
+}
+
 - (void)shortcutRecorder:(SRRecorderControl *)recorder keyComboDidChange:(KeyCombo)newKeyCombo {
-    NSString *identifier = [hotKeyControls_ keyForObject:recorder];
+    NSString *identifier = recorder.identifier;
     FMTAssertNotNil(identifier);
 
     ShiftItAction *action = [allShiftActions objectForKey:identifier];
@@ -243,23 +267,23 @@ NSString *const kHotKeysTabViewItemIdentifier = @"hotKeys";
 }
 
 - (void)updateRecorderCombos {
-    NSInteger idx = [tabView_ indexOfTabViewItemWithIdentifier:@"hotKeys"];
-    NSView *hotKeysView = [[tabView_ tabViewItemAtIndex:idx] view];
-    FMTAssertNotNil(hotKeysView);
-
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-
-    for (ShiftItAction *action in [allShiftActions allValues]) {
-        NSString *identifier = [action identifier];
-        SRRecorderControl *recorder = [hotKeyControls_ objectForKey:identifier];
-        FMTAssertNotNil(recorder);
-
-
-        KeyCombo combo;
-        combo.code = [defaults integerForKey:KeyCodePrefKey(identifier)];
-        combo.flags = [defaults integerForKey:ModifiersPrefKey(identifier)];
-        [recorder setKeyCombo:combo];
+    for (int row = 0; row < sizeof(hotkeyIdentifiers) / sizeof(hotkeyIdentifiers[0]); ++row) {
+        NSString* identifier = hotkeyIdentifiers[row];
+        if (identifier == NULL)
+            continue;
+        SRRecorderControl *recorder = [hotkeysView_ viewAtColumn:1 row:row makeIfNecessary:NO];
+        if (recorder == NULL)
+            continue;
+        [self updateRecorderCombo:recorder forIdentifier:identifier];
     }
+}
+
+- (void)updateRecorderCombo:(SRRecorderControl *)recorder forIdentifier:(NSString *)identifier {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    KeyCombo combo;
+    combo.code = [defaults integerForKey:KeyCodePrefKey(identifier)];
+    combo.flags = [defaults integerForKey:ModifiersPrefKey(identifier)];
+    [recorder setKeyCombo:combo];
 }
 
 #pragma mark TabView delegate methods


### PR DESCRIPTION
Don't know if you like it or not, I'm sorry if you don't, but during adding a row to Hotkeys tab in Preferences, I felt it's a bit of pain to layout new labels and SRRecorderControl correctly.

So the proposal is to use NSTableView and programmatically populate these controls. I guess I should have discussed about the change before sending a pull request, but the code was done while I was learning and playing to see how well it'll fit. Please feel free to reject and close if you don't like the approach.

Note that I've made it not to look like an NSTableView but keeps exact the same visual as before. I could change them back to look like an NSTableView if you like, either now or in future when you'll need scrolling behavior.

For now, I think the benefits are easier to layout, with exactly the same pitch, and easier to maintain, so I chose not  to change the visuals as much as possible.

I hope you like it.
