### PR TITLE
Fixes xib regressions

### DIFF
--- a/ShiftIt/Base.lproj/PreferencesWindow.xib
+++ b/ShiftIt/Base.lproj/PreferencesWindow.xib
@@ -632,7 +632,7 @@
                             <tabViewItem label="Anchors" identifier="anchors" id="1010">
                                 <view key="view" id="1011">
                                     <rect key="frame" x="32" y="7" width="299" height="460"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button id="1038">
                                             <rect key="frame" x="9" y="427" width="120" height="18"/>


### PR DESCRIPTION
Moved fixes for XIB regressions from discussions in #132 to a separate pull request so that you could review diffs easier on the github site.

During enabling localizations and merging the patch to release/1.6.1 branch, some hunks are likely to be accidentally included and looks errors to me.

This is a pull request to fix all regressions introduced by the merge.
## Diff Examinations

The original diff that includes possible errors is unfortunately a bit hard to view because the XIB was moved and duplicated in the same commit, and git does not show diff of the XIB file in two revisions clearly.

To look at the diff, 4e1eef3 reverts all the changes made to base XIB file. And then following commits in this pull request re-apply hunks that look reasonable to me. By looking at changed files of this pull request, you're seeing these (revert and re-apply) patches combined.

If you prefer text rather than diff, here's a summary:
1. `<deployment defaultVersion>` was changed from `1070` to `1080`. This is probably ok as I can see project targets 10.8 now.
2. `showMenuIcon` outlet was removed. This is probably an error, I reverted in this patch.
3. `metafont="system"` was changed to `LucidaGrande`. This is probably an error, reverted.
4. Two `<buttonCell key="prototype">` were removed. I can't find documents on this element, but by guessing from name, it's a prototype for its child elements. Maybe newer Xcode removes it automatically, but reverted anyway since the removal doesn't look intentional nor meaningful.
5. Logo `imageScaling` was changed from `proportionallyDown` to `proportionallyUpOrDown`. Not a bad change if Apple is going to release x4 Retina ;-)
6. A connection to an action `showMenuBarIconAction:` in `Show Icon In Menu Bar` was removed. This is probably an error, reverted.
7. `widthSizable="YES" heightSizable="YES"` were added in `autoresizingMask` element. This looks like a good change as Apple recommends more auto-sizing and auto-layout.
8. `numberFormatter` were changed to hard-code properties such as `decimalSeparator="."`. I suppose this is accidental, and is probably a non-welcoming change since using "." as a decimal separator isn't good for some European languages.
9. A typo fix ab876c2 was reverted, probably accidentally. Reverted the revert (re-applied) in this patch.
