### PR TITLE
Fix MacPorts paths

### DIFF
--- a/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
+++ b/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
@@ -1010,13 +1010,15 @@
 				GCC_PREFIX_HEADER = ShiftIt_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "_DEBUGPRINTS_=1";
 				HEADER_SEARCH_PATHS = (
-					/usr/X11/include,
+					/opt/local/include,
 					/opt/X11/include,
+					/usr/X11/include,
 				);
 				INFOPLIST_FILE = "ShiftIt-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
-					/usr/X11/lib,
+					/opt/local/lib,
 					/opt/X11/lib,
+					/usr/X11/lib,
 				);
 				OTHER_CFLAGS = (
 					"-DDEBUG",
@@ -1035,13 +1037,15 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ShiftIt_Prefix.pch;
 				HEADER_SEARCH_PATHS = (
-					/usr/X11/include,
+					/opt/local/include,
 					/opt/X11/include,
+					/usr/X11/include,
 				);
 				INFOPLIST_FILE = "ShiftIt-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
-					/usr/X11/lib,
+					/opt/local/lib,
 					/opt/X11/lib,
+					/usr/X11/lib,
 				);
 				OTHER_CFLAGS = (
 					"-DNDEBUG",

--- a/ShiftIt/X11WindowDriver.m
+++ b/ShiftIt/X11WindowDriver.m
@@ -35,10 +35,10 @@ NSInteger const kX11WindowDriverErrorCode = 20105;
 // TODO: extract
 static char *X11Paths_[] = {
 	"libX11.6.dylib",
-    "/usr/local/X11/libX11.6.dylib", // anyone?
-    "/opt/X11/lib/libX11.6.dylib", // XQuartz, needs be tried before regular
-	"/usr/X11/lib/libX11.6.dylib", // regular
+	"/usr/local/X11/libX11.6.dylib", // anyone?
 	"/opt/local/lib/libX11.6.dylib", // MacPorts
+	"/opt/X11/lib/libX11.6.dylib", // XQuartz, needs be tried before regular
+	"/usr/X11/lib/libX11.6.dylib", // regular
 	"/sw/X11/lib/libX11.6.dylib", // Fink?
 };
 

--- a/ShiftIt/X11WindowDriver.m
+++ b/ShiftIt/X11WindowDriver.m
@@ -38,7 +38,7 @@ static char *X11Paths_[] = {
     "/usr/local/X11/libX11.6.dylib", // anyone?
     "/opt/X11/lib/libX11.6.dylib", // XQuartz, needs be tried before regular
 	"/usr/X11/lib/libX11.6.dylib", // regular
-	"/opt/local/X11/lib/libX11.6.dylib", // MacPorts?
+	"/opt/local/lib/libX11.6.dylib", // MacPorts
 	"/sw/X11/lib/libX11.6.dylib", // Fink?
 };
 


### PR DESCRIPTION
and prefer MacPorts over XQuartz and regular OS X versions which are rather old. (Even older than the latest xorg security errata.)