### PR TITLE
Youtube Mobile Fix

### DIFF
--- a/ShiftIt/DefaultShiftItActions.m
+++ b/ShiftIt/DefaultShiftItActions.m
@@ -39,7 +39,7 @@ const SimpleWindowGeometryChangeBlock shiftItRight = ^AnchoredRect(NSRect window
     r.origin.x = screenSize.width / 2;
     r.origin.y = 0;
 
-    r.size.width = screenSize.width / 2;
+    r.size.width = screenSize.width / 2 + 1;
     r.size.height = screenSize.height;
 
     return MakeAnchoredRect(r, kRightDirection);


### PR DESCRIPTION
With the latest Youtube responsive design, on my MacBook Retina I'm no longer able to put two windows side by side with the left one playing Youtube with a normal video player width. The width shrinks to mobile size based as the the Youtube mobile layout triggers exactly at half of my screen width, that's why I'm adding an extra pixel to avoid this issue. This still happens if you place the Youtube video on the right. I know this may be annoying to a lot of people who don't care about Youtube but this is the only use case I really have for ShiftIt to watch a Youtube video side by side another window.