### PR TITLE
Add 10.8 fallback conditions (Issue #166)

### DIFF
--- a/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
+++ b/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
@@ -221,6 +221,10 @@
 		83E55ED4125A5FCF00FC49BF /* ShiftIt.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ShiftIt.icns; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* ShiftIt-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ShiftIt-Info.plist"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* ShiftIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShiftIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3166F1A1AF36971003F7A48 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/PreferencesWindow.strings; sourceTree = "<group>"; };
+		C3166F1B1AF36971003F7A48 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		C3166F1C1AF36971003F7A48 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C3166F1D1AF36971003F7A48 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E4BCF097E2A6742AD696580E /* SIAdjacentRectanglesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIAdjacentRectanglesTest.m; sourceTree = "<group>"; };
 		E4BCF1236CA369B89F718229 /* ShiftIt Tests-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ShiftIt Tests-Prefix.pch"; sourceTree = "<group>"; };
 		E4BCF6EB42F45803C08BAC36 /* FMTError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMTError.m; sourceTree = "<group>"; };
@@ -857,6 +861,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				27632BCC19535FD0000445C5 /* Base */,
+				C3166F1D1AF36971003F7A48 /* en */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -866,6 +871,7 @@
 			children = (
 				27632BCA19535F04000445C5 /* Base */,
 				27632BD2195364EB000445C5 /* ja */,
+				C3166F1D1AF36971003F7A48 /* en */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";
@@ -875,6 +881,7 @@
 			children = (
 				27632BC919535F04000445C5 /* Base */,
 				27632BD1195364EB000445C5 /* ja */,
+				C3166F1D1AF36971003F7A48 /* en */,
 			);
 			name = PreferencesWindow.xib;
 			sourceTree = "<group>";
@@ -884,6 +891,7 @@
 			children = (
 				27632BCB19535F87000445C5 /* Base */,
 				27632BD3195364EB000445C5 /* ja */,
+				C3166F1D1AF36971003F7A48 /* en */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/ShiftIt/ShiftItAppDelegate.m
+++ b/ShiftIt/ShiftItAppDelegate.m
@@ -368,7 +368,7 @@ NSDictionary *allShiftActions = nil;
                 }
 
             }
-        } else {
+        } else if (!AXAPIEnabled()){
             // OSX <= 10.8
             NSAlert *alert = [NSAlert alertWithMessageText:NSLocalizedString(@"Authorization Required", nil)
                                              defaultButton:NSLocalizedString(@"Quit", nil)

--- a/ShiftIt/en.lproj/InfoPlist.strings
+++ b/ShiftIt/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/ShiftIt/en.lproj/Localizable.strings
+++ b/ShiftIt/en.lproj/Localizable.strings
@@ -1,0 +1,36 @@
+/* 
+  Localizable.strings
+  ShiftIt
+
+  Created by Hiroyuki Kurosawa on 2013/11/16.
+
+*/
+
+"Left" = "Left";
+"Right" = "Right";
+"Top" = "Top";
+"Bottom" = "Bottom";
+"Top Left" = "Top Left";
+"Top Right" = "Top Right";
+"Bottom Left" = "Bottom Left";
+"Bottom Right" = "Bottom Right";
+"Center" = "Center";
+"Toggle Zoom" = "Toggle Zoom";
+"Maximize" = "Maximize";
+"Toggle Full Screen" = "Toggle Full Screen";
+"Increase" = "Increase";
+"Reduce" = "Reduce";
+"Next Screen" = "Next Screen";
+"Previous Screen" = "Previous Screen";
+
+"Authorization Required" = "Authorization Required";
+"Recheck" = "Recheck";
+"Open System Preferences" = "Open System Preferences";
+"Quit" = "Quit";
+"AUTHORIZATION_INFORMATIVE_TEXT_10_9" = "ShiftIt needs to be authorized to use an Accessibility Services in order to be able to move and resize application windows.\n\nYou can do this in System Preferences > Security & Privacy > Privacy > Accessibility. You might need to drag-and-drop ShiftIt into the list of allowed apps and make sure the checkbox is on.";
+"AUTHORIZATION_INFORMATIVE_TEXT_10_8" = "ShiftIt needs to be authorized to use an Accessibility Services in order to be able to move and resize application windows.\n\nPlease \"Enable access for assistive devices\" in the System Preferences > Universal Access and then restart ShiftIt.";
+
+"Start ShiftIt automatically?" = "Start ShiftIt automatically?";
+"Would you like to have ShiftIt automatically started at a login time?" = "Would you like to have ShiftIt automatically started at a login time?";
+"Yes" = "Yes";
+"No" = "No";

--- a/ShiftIt/en.lproj/MainMenu.strings
+++ b/ShiftIt/en.lproj/MainMenu.strings
@@ -1,0 +1,60 @@
+
+/* Class = "NSMenu"; title = "Status Menu"; ObjectID = "535"; */
+"535.title" = "Status Menu";
+
+/* Class = "NSMenuItem"; title = "Center"; ObjectID = "537"; */
+"537.title" = "Center";
+
+/* Class = "NSMenuItem"; title = "Toggle Full Screen"; ObjectID = "545"; */
+"545.title" = "Toggle Full Screen";
+
+/* Class = "NSMenuItem"; title = "Quit ShiftIt"; ObjectID = "546"; */
+"546.title" = "Quit ShiftIt";
+
+/* Class = "NSMenuItem"; title = "Left"; ObjectID = "547"; */
+"547.title" = "Left";
+
+/* Class = "NSMenuItem"; title = "Right"; ObjectID = "548"; */
+"548.title" = "Right";
+
+/* Class = "NSMenuItem"; title = "Top"; ObjectID = "549"; */
+"549.title" = "Top";
+
+/* Class = "NSMenuItem"; title = "Bottom"; ObjectID = "550"; */
+"550.title" = "Bottom";
+
+/* Class = "NSMenuItem"; title = "Preferences"; ObjectID = "558"; */
+"558.title" = "Preferences";
+
+/* Class = "NSMenuItem"; title = "Check for Updates"; ObjectID = "761"; */
+"761.title" = "Check for Updates";
+
+/* Class = "NSMenuItem"; title = "Top Left"; ObjectID = "767"; */
+"767.title" = "Top Left";
+
+/* Class = "NSMenuItem"; title = "Top Right"; ObjectID = "768"; */
+"768.title" = "Top Right";
+
+/* Class = "NSMenuItem"; title = "Bottom Left"; ObjectID = "769"; */
+"769.title" = "Bottom Left";
+
+/* Class = "NSMenuItem"; title = "Bottom Right"; ObjectID = "770"; */
+"770.title" = "Bottom Right";
+
+/* Class = "NSMenuItem"; title = "Increase"; ObjectID = "786"; */
+"786.title" = "Increase";
+
+/* Class = "NSMenuItem"; title = "Reduce"; ObjectID = "787"; */
+"787.title" = "Reduce";
+
+/* Class = "NSMenuItem"; title = "Toggle Zoom"; ObjectID = "791"; */
+"791.title" = "Toggle Zoom";
+
+/* Class = "NSMenuItem"; title = "Maximize"; ObjectID = "792"; */
+"792.title" = "Maximize";
+
+/* Class = "NSMenuItem"; title = "Next Screen"; ObjectID = "794"; */
+"794.title" = "Next Screen";
+
+/* Class = "NSMenuItem"; title = "Previous Screen"; ObjectID = "URi-Kh-uDb"; */
+"URi-Kh-uDb.title" = "Previous Screen";

--- a/ShiftIt/en.lproj/PreferencesWindow.strings
+++ b/ShiftIt/en.lproj/PreferencesWindow.strings
@@ -1,0 +1,123 @@
+
+/* Class = "NSWindow"; title = "Preferences"; ObjectID = "1"; */
+"1.title" = "Preferences";
+
+/* Class = "NSTabViewItem"; label = "General"; ObjectID = "5"; */
+"5.label" = "General";
+
+/* Class = "NSButtonCell"; title = "Open At Login"; ObjectID = "63"; */
+"63.title" = "Open At Login";
+
+/* Class = "NSButtonCell"; title = "Automatically Check For Updates"; ObjectID = "65"; */
+"65.title" = "Automatically Check For Updates";
+
+/* Class = "NSButtonCell"; title = "Check For Updates Now"; ObjectID = "67"; */
+"67.title" = "Check For Updates Now";
+
+/* Class = "NSButtonCell"; title = "Show Icon In Menu Bar"; ObjectID = "257"; */
+"257.title" = "Show Icon In Menu Bar";
+
+/* Class = "NSTabViewItem"; label = "Hotkeys"; ObjectID = "394"; */
+"394.label" = "Hotkeys";
+
+/* Class = "NSTextFieldCell"; title = "ShiftIt App"; ObjectID = "583"; */
+"583.title" = "ShiftIt App";
+
+/* Class = "NSTextFieldCell"; title = "version"; ObjectID = "585"; */
+"585.title" = "version";
+
+/* Class = "NSButtonCell"; title = "Restore defaults"; ObjectID = "607"; */
+"607.title" = "Restore defaults";
+
+/* Class = "NSTabViewItem"; label = "Increase/Reduce"; ObjectID = "632"; */
+"632.label" = "Increase/Reduce";
+
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "730"; */
+"730.title" = "Size:";
+
+/* Class = "NSButtonCell"; title = "Fixed"; ObjectID = "732"; */
+"732.title" = "Fixed";
+
+/* Class = "NSButtonCell"; title = "Window"; ObjectID = "733"; */
+"733.title" = "Window";
+
+/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "734"; */
+"734.title" = "Radio";
+
+/* Class = "NSButtonCell"; title = "Screen"; ObjectID = "735"; */
+"735.title" = "Screen";
+
+/* Class = "NSTextFieldCell"; title = "100"; ObjectID = "737"; */
+"737.title" = "100";
+
+/* Class = "NSTextFieldCell"; title = "99.25"; ObjectID = "740"; */
+"740.title" = "99.25";
+
+/* Class = "NSTextFieldCell"; title = "%"; ObjectID = "748"; */
+"748.title" = "%";
+
+/* Class = "NSTextFieldCell"; title = "%"; ObjectID = "750"; */
+"750.title" = "%";
+
+/* Class = "NSTextFieldCell"; title = "px"; ObjectID = "802"; */
+"802.title" = "px";
+
+/* Class = "NSTextFieldCell"; title = "px"; ObjectID = "804"; */
+"804.title" = "px";
+
+/* Class = "NSTextFieldCell"; title = "width"; ObjectID = "806"; */
+"806.title" = "width";
+
+/* Class = "NSTextFieldCell"; title = "height"; ObjectID = "808"; */
+"808.title" = "height";
+
+/* Class = "NSButtonCell"; title = "Quit ShiftIt"; ObjectID = "814"; */
+"814.title" = "Quit ShiftIt";
+
+/* Class = "NSButtonCell"; title = "Include Window Drawers"; ObjectID = "820"; */
+"820.title" = "Include Window Drawers";
+
+/* Class = "NSButtonCell"; title = "Show Icon In Menu Bar"; ObjectID = "828"; */
+"828.title" = "Show Icon In Menu Bar";
+
+/* Class = "NSTabViewItem"; label = "Advanced"; ObjectID = "837"; */
+"837.label" = "Advanced";
+
+/* Class = "NSButtonCell"; title = "Enable debug logging"; ObjectID = "862"; */
+"862.title" = "Enable debug logging";
+
+/* Class = "NSTextFieldCell"; title = "If you experience any problems, allowing this extra logging output might help trace it down more easily. Once on, all logging will be redirected to a file that appears below. Please attach the logging file to any issue you are reporting on github.com."; ObjectID = "864"; */
+"864.title" = "If you experience any problems, allowing this extra logging output might help trace it down more easily. Once on, all logging will be redirected to a file that appears below. Please attach the logging file to any issue you are reporting on github.com.";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "866"; */
+"866.title" = "Label";
+
+/* Class = "NSTabViewItem"; label = "Anchors"; ObjectID = "1010"; */
+"1010.label" = "Anchors";
+
+/* Class = "NSButtonCell"; title = "Enable Anchors"; ObjectID = "1039"; */
+"1039.title" = "Enable Anchors";
+
+/* Class = "NSTextFieldCell"; title = "Anchors define margins of a screen. If a window is inside one of these margins it will be automatically anchored to the respective side with next actions that is executed. This is useful especially for application like Terminal.app or other that do not change their sizes continously, but rather in a descrete steps."; ObjectID = "1040"; */
+"1040.title" = "Anchors define margins of a screen. If a window is inside one of these margins it will be automatically anchored to the respective side with next actions that is executed. This is useful especially for application like Terminal.app or other that do not change their sizes continously, but rather in a descrete steps.";
+
+/* Class = "NSTextFieldCell"; title = "It should work fine in most cases, but eventually you might experience some weird behavior with drawers. Please, before reporting a new issue, check the list if there is not already one."; ObjectID = "1828"; */
+"1828.title" = "It should work fine in most cases, but eventually you might experience some weird behavior with drawers. Please, before reporting a new issue, check the list if there is not already one.";
+
+/* Class = "NSButtonCell"; title = "Report New Issue"; ObjectID = "1833"; */
+"1833.title" = "Report New Issue";
+
+/* Class = "NSButtonCell"; title = "Reveal In Finder"; ObjectID = "1837"; */
+"1837.title" = "Reveal In Finder";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "3ss-15-jqT"; */
+"3ss-15-jqT.title" = "Table View Cell";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "9br-JZ-gxa"; */
+"9br-JZ-gxa.title" = "Table View Cell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "NP6-3N-EpU"; */
+"NP6-3N-EpU.title" = "Text Cell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "jiH-Xs-9qQ"; */
+"jiH-Xs-9qQ.title" = "Text Cell";


### PR DESCRIPTION
Added the necessary files and code for localized messages to show as expected on OS X 10.8. Also included the conditional that checks if the assistive devices have access only when running OS X 10.8 or lower.