### PR TITLE
Allow shifting to 1/3, 1/2, 2/3 of total size.

### DIFF
--- a/ShiftIt/DefaultShiftItActions.h
+++ b/ShiftIt/DefaultShiftItActions.h
@@ -21,6 +21,7 @@
 #import "WindowGeometryShiftItAction.h"
 #import "ShiftIt.h"
 
+BOOL CloseTo(double a, double b);
 const extern SimpleWindowGeometryChangeBlock shiftItLeft;
 const extern SimpleWindowGeometryChangeBlock shiftItRight;
 const extern SimpleWindowGeometryChangeBlock shiftItTop;

--- a/ShiftIt/DefaultShiftItActions.m
+++ b/ShiftIt/DefaultShiftItActions.m
@@ -21,14 +21,27 @@
 // TODO: extract this to be out of here
 #import "ShiftItApp.h"
 
+BOOL CloseTo(double a, double b) {
+  return fabs(a - b) < 20;
+}
+
 const SimpleWindowGeometryChangeBlock shiftItLeft = ^AnchoredRect(NSRect windowRect, NSSize screenSize) {
     NSRect r = NSMakeRect(0, 0, 0, 0);
 
     r.origin.x = 0;
     r.origin.y = 0;
 
-    r.size.width = screenSize.width / 2;
+    double w = windowRect.size.width;
+    double sw = screenSize.width;
+
+    r.size.width = screenSize.width / 2.0;
     r.size.height = screenSize.height;
+
+    if (CloseTo(w, sw / 2.0)) {
+      r.size.width = floor(sw * 1.0 / 3.0);
+    } else if (CloseTo(w, sw / 3.0)) {
+      r.size.width = floor(sw * 2.0 / 3.0);
+    }
 
     return MakeAnchoredRect(r, kLeftDirection);
 };
@@ -39,8 +52,19 @@ const SimpleWindowGeometryChangeBlock shiftItRight = ^AnchoredRect(NSRect window
     r.origin.x = screenSize.width / 2;
     r.origin.y = 0;
 
-    r.size.width = screenSize.width / 2;
+    r.size.width = screenSize.width / 2.0;
     r.size.height = screenSize.height;
+
+    double w = windowRect.size.width;
+    double sw = screenSize.width;
+
+    if (CloseTo(w, sw / 2.0)) {
+      r.size.width = floor(sw * 1.0 / 3.0);
+      r.origin.x = sw - (sw * 1.0 / 3.0);
+    } else if (CloseTo(w, sw / 3.0)) {
+      r.size.width = floor(sw * 2.0 / 3.0);
+      r.origin.x = sw - (sw * 2.0 / 3.0);
+    }
 
     return MakeAnchoredRect(r, kRightDirection);
 };
@@ -54,6 +78,17 @@ const SimpleWindowGeometryChangeBlock shiftItTop = ^AnchoredRect(NSRect windowRe
     r.size.width = screenSize.width;
     r.size.height = screenSize.height / 2;
 
+    double windowHeight = windowRect.size.height;
+    double screenHeight = screenSize.height;
+
+    if (CloseTo(windowHeight, screenHeight / 2.0)) {
+      r.size.height = floor(screenHeight * 1.0 / 3.0);
+      r.origin.y = screenHeight * 1.0 / 3.0;
+    } else if (CloseTo(windowHeight, screenHeight / 3.0)) {
+      r.size.height = floor(screenHeight * 2.0 / 3.0);
+      r.origin.y = screenHeight * 2.0 / 3.0;
+    }
+
     return MakeAnchoredRect(r, kTopDirection);
 };
 
@@ -65,6 +100,17 @@ const SimpleWindowGeometryChangeBlock shiftItBottom = ^AnchoredRect(NSRect windo
 
     r.size.width = screenSize.width;
     r.size.height = screenSize.height / 2;
+
+    double windowHeight = windowRect.size.height;
+    double screenHeight = screenSize.height;
+
+    if (CloseTo(windowHeight, screenHeight / 2.0)) {
+      r.size.height = floor(screenHeight * 1.0 / 3.0);
+      r.origin.y = screenHeight - (screenHeight * 1.0 / 3.0);
+    } else if (CloseTo(windowHeight, screenHeight / 3.0)) {
+      r.size.height = floor(screenHeight * 2.0 / 3.0);
+      r.origin.y = screenHeight - (screenHeight * 2.0 / 3.0);
+    }
 
     return MakeAnchoredRect(r, kBottomDirection);
 };


### PR DESCRIPTION
Hey all! I'm a big fan of ShiftIt. Thanks to all the contributors for keeping this app out there.

I've been using @onsi's fork of the app for the last year and I've gotten used to being able to toggle between window sizes. I wanted to see that feature over on this fork. A few folks have mentioned that they'd like to see something like this in Issue #183 and Issue #148.

My work was  based on this commit I saw on the other fork. Check out [this commit](https://github.com/onsi/ShiftIt/commit/99948f0a64742b210f79f0ec287cd8d87d4599a0) for reference.

Feedback would be great! I don't write very much Objective-C, so this is new territory for me.