### PR TITLE
Fix 1.6.5 release path

### DIFF
--- a/release/appcast.xml
+++ b/release/appcast.xml
@@ -10,7 +10,7 @@
                     http://htmlpreview.github.com/?https://raw.github.com/fikovnik/ShiftIt/master/release/release-notes-1.6.5.html
                 </sparkle:releaseNotesLink>
             <pubDate>Wed, 07 Feb 2018 08:49:01 </pubDate>
-            <enclosure url="https://github.com/fikovnik/ShiftIt/releases/download/version-1.6.5/ShiftIt-1.6.5.zip" sparkle:version="1.6.5" length="831610" type="application/octet-stream" sparkle:dsaSignature="MC0CFBNxzUGUKmss+ufYQolF1f2d6H40AhUAyHTl6P32ydT7wPPRj5+26DvZ1Fs=" />
+            <enclosure url="https://github.com/fikovnik/ShiftIt/releases/download/1.6.5/ShiftIt-1.6.5.zip" sparkle:version="1.6.5" length="831610" type="application/octet-stream" sparkle:dsaSignature="MC0CFBNxzUGUKmss+ufYQolF1f2d6H40AhUAyHTl6P32ydT7wPPRj5+26DvZ1Fs=" />
          </item>
    </channel>
 </rss>


### PR DESCRIPTION
Hey! This should fix #265 

The release path was giving a 404. That being said, I know nothing about Sparkle, I just fixed the path. There may be steps left after that to make the auto updater work?