### PR TITLE
Fix #247 (crash when X11WindowDriver failed to get window properties)

### DIFF
--- a/ShiftIt/X11WindowDriver.m
+++ b/ShiftIt/X11WindowDriver.m
@@ -345,7 +345,7 @@ static BOOL execWithDisplay_(ExecWithDisplayBlock block, NSError ** error) {
     Window __block * windowRef;
 
     // find the focused window
-    execWithDisplay_(^BOOL(Display *dpy, NSError **nestedError) {
+    BOOL result = execWithDisplay_(^BOOL(Display *dpy, NSError **nestedError) {
         Window root = DefaultRootWindow(dpy);
 
         // following are for the params that are not used
@@ -372,6 +372,9 @@ static BOOL execWithDisplay_(ExecWithDisplayBlock block, NSError ** error) {
     }, error);
 
     // verify that this is the window that we were asked to find
+    if (!result) {
+        return NO;
+    }
 
 
     *window = [[[X11Window alloc] initWithRef:windowRef driver:self] autorelease];


### PR DESCRIPTION
X11WindowDriver uses `XGetWindowPropertyRef` to get a reference
to the properties of the active window. If this fails, however,
the outer function findFocusedWindow does not return "NO" to
indicate failure, because the result of the inner block is
ignored. This change makes sure findFocusedWindow returns "NO" if the
inner block returns "NO".

Reproduce/test by using a GTK window, like sylpheed as suggested in the window, or this ginput/matplotlib Python script:
```
import matplotlib.pyplot as plt
plt.title("test ginput")
x = plt.ginput(n=0, timeout=-1)
```

Trying to use ShiftIt on the window still won't work, but ShiftIt will no longer crash.

Fixes #247 .