### PR TITLE
Updated Install command for mac-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ xcodebuild -target "ShiftIt NoX11" -configuration Release
 To install  ShiftIt using brew you can use the cask.
 
 ```
-$ brew cask install shiftit
+$ brew install --cask shiftit
 ```
 
 ### Making a release


### PR DESCRIPTION
previous command uses `cask` which does not work anymore on mac. Therefore, a small change of `--cask` fixes this to work fine.